### PR TITLE
Change sorting of locations in the pack putaway computation

### DIFF
--- a/stock_storage_type/README.rst
+++ b/stock_storage_type/README.rst
@@ -62,16 +62,16 @@ storage type.
 
 Storage locations linked to the package storage are processed sequentially, if
 said storage location is a child of the move line's destination location (i.e
-either the put-away location or the move's destination location), then it will
-be searched in order to find a children location that is allowed according to
-the restrictions defined on the stock location storage types.
+either the put-away location or the move's destination location).
+For each location, their packs storage strategy is applied as well as the
+restrictions defined on the stock location storage types.
 If no suitable location is found, the next location in the sequence will be
 searched and so on.
 
-.. IMPORTANT::
-   This is an alpha version, the data model and design can change at any time without warning.
-   Only for development or testing purpose, do not use in production.
-   `More details on development status <https://odoo-community.org/page/development-status>`_
+For the packs putaway strategy "none", the location is considered as is.  For
+the "ordered children" strategy, children locations are sorted by first by max
+height which is a physical constraint to respect, then pack putaway sequence
+which allow to favor for example some level or corridor, and finally by name.
 
 **Table of contents**
 
@@ -119,12 +119,14 @@ Authors
 ~~~~~~~
 
 * Camptocamp
+* BCIM
 
 Contributors
 ~~~~~~~~~~~~
 
 * Akim Juillerat <akim.juillerat@camptocamp.com>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Jacques-Etienne Baudoux <je@bcim.be>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_storage_type/__manifest__.py
+++ b/stock_storage_type/__manifest__.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 Camptocamp SA
+# Copyright 2019-2021 Camptocamp SA
+# Copyright 2019-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 {
     "name": "Stock Storage Type",
     "summary": "Manage packages and locations storage types",
-    "version": "10.0.1.12.0",
+    "version": "10.0.1.13.0",
     "development_status": "Alpha",
     "category": "Warehouse Management",
     "website": "https://github.com/OCA/wms",
-    "author": "Camptocamp, ACSONE SA/NV, Odoo Community Association (OCA)",
+    "author": "Camptocamp, BCIM, ACSONE SA/NV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/stock_storage_type/demo/stock_location.xml
+++ b/stock_storage_type/demo/stock_location.xml
@@ -25,6 +25,10 @@
         <field name="name">Bin 3</field>
         <field name="location_id" ref="stock_location_cardboxes" />
     </record>
+    <record id="stock_location_cardboxes_bin_4" model="stock.location">
+        <field name="name">Bin 4</field>
+        <field name="location_id" ref="stock_location_cardboxes" />
+    </record>
     <record id="stock_location_pallets" model="stock.location">
         <field name="name">Pallets storage area</field>
         <field
@@ -48,6 +52,10 @@
     </record>
     <record id="stock_location_pallets_bin_3" model="stock.location">
         <field name="name">Pallets Bin 3</field>
+        <field name="location_id" ref="stock_location_pallets" />
+    </record>
+    <record id="stock_location_pallets_bin_4" model="stock.location">
+        <field name="name">Pallets Bin 4</field>
         <field name="location_id" ref="stock_location_pallets" />
     </record>
     <record id="stock_location_pallets_reserve" model="stock.location">
@@ -75,6 +83,10 @@
         <field name="name">Pallets Reserve Bin 3</field>
         <field name="location_id" ref="stock_location_pallets_reserve" />
     </record>
+    <record id="stock_location_pallets_reserve_bin_4" model="stock.location">
+        <field name="name">Pallets Reserve Bin 4</field>
+        <field name="location_id" ref="stock_location_pallets_reserve" />
+    </record>
     <record id="stock_location_cardboxes_reserve" model="stock.location">
         <field name="name">Cardboxes reserve storage area</field>
         <field
@@ -98,6 +110,10 @@
     </record>
     <record id="stock_location_cardboxes_reserve_bin_3" model="stock.location">
         <field name="name">Cardboxes Reserve Bin 3</field>
+        <field name="location_id" ref="stock_location_cardboxes_reserve" />
+    </record>
+    <record id="stock_location_cardboxes_reserve_bin_4" model="stock.location">
+        <field name="name">Cardboxes Reserve Bin 4</field>
         <field name="location_id" ref="stock_location_cardboxes_reserve" />
     </record>
 </odoo>

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 Camptocamp SA
+# Copyright 2019-2021 Camptocamp SA
+# Copyright 2019-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 import logging
+
+from psycopg2 import sql
 
 from odoo import api, fields, models
 from odoo.tools import float_compare
@@ -50,6 +53,7 @@ class StockLocation(models.Model):
         "locations according to the restrictions defined on their "
         "respective location storage types.",
     )
+    pack_putaway_sequence = fields.Integer()
     storage_location_sequence_ids = fields.One2many(
         "stock.storage.location.sequence",
         "location_id",
@@ -372,9 +376,50 @@ class StockLocation(models.Model):
         locations = self.browse()
         if self.pack_putaway_strategy == "none":
             locations = self
-        elif self.pack_putaway_strategy == "ordered_locations":
-            locations = self._get_ordered_leaf_locations()
+        else:
+            locations = self._get_sorted_leaf_locations(products)
         return locations
+
+    def _get_sorted_leaf_locations_orderby(self, products):
+        """Return SQL orderby clause and params for sorting locations
+
+        First, locations are ordered by max height, knowing that a max height of 0
+        means "no limit" and as such it should be among the last locations.
+        Then, they are ordered by a sequence and name.
+        """
+        orderby = []
+        if self.pack_putaway_strategy == "ordered_locations":
+            orderby = [
+                "CASE WHEN max_height > 0 THEN max_height ELSE 'Infinity' END",
+                "pack_putaway_sequence",
+                "name",
+            ]
+        return ", ".join(orderby), []
+
+    def _get_sorted_leaf_locations(self, products):
+        """Return sorted leaf sub-locations
+
+        The locations are candidate locations that will be evaluated one per
+        one in order to find the first available location. They must be leaf
+        locations where we can actually put goods.
+        """
+        if not self.leaf_location_ids:
+            return self.leaf_location_ids
+        query = self._where_calc([("id", "in", self.leaf_location_ids.ids)])
+        from_clause, where_clause, where_params = query.get_sql()
+        orderby_clause, orderby_params = self._get_sorted_leaf_locations_orderby(
+            products
+        )
+        query = sql.SQL(
+            "SELECT id FROM {table} WHERE {where} ORDER BY {orderby}"
+        ).format(
+            table=sql.Identifier(self._table),
+            where=sql.SQL(where_clause),
+            orderby=sql.SQL(orderby_clause),
+        )
+        self._cr.execute(query, where_params + orderby_params)
+        location_ids = [x[0] for x in self.env.cr.fetchall()]
+        return self.env["stock.location"].browse(location_ids)
 
     def select_first_allowed_location(self, package_storage_type, quants, products):
         allowed = self.select_allowed_locations(
@@ -539,24 +584,6 @@ class StockLocation(models.Model):
         ]
         valid_locations = self.browse(ordered_valid_location_ids)
         return valid_locations
-
-    def _get_ordered_leaf_locations(self):
-        """Return ordered leaf sub-locations
-
-        The locations are candidate locations that will be evaluated one per
-        one in order to find the first available location. They must be leaf
-        locations where we can actually put goods.
-
-        Locations are ordered by max height, knowing that a max height of 0
-        means "no limit" and as such it should be among the last locations.
-        """
-        leaf_location_ids = self.mapped("leaf_location_ids")
-        if not leaf_location_ids:
-            return leaf_location_ids
-        max_height = max(self.mapped("leaf_location_ids.max_height"))
-        return leaf_location_ids.sorted(
-            lambda l: l.max_height if l.max_height else (max_height + 1)
-        )
 
     def write(self, vals):
         res = super(StockLocation, self).write(vals)

--- a/stock_storage_type/readme/CONTRIBUTORS.rst
+++ b/stock_storage_type/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Akim Juillerat <akim.juillerat@camptocamp.com>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Jacques-Etienne Baudoux <je@bcim.be>
 * Laurent Mignon <laurent.mignon@acsone.eu>

--- a/stock_storage_type/readme/DESCRIPTION.rst
+++ b/stock_storage_type/readme/DESCRIPTION.rst
@@ -35,8 +35,13 @@ storage type.
 
 Storage locations linked to the package storage are processed sequentially, if
 said storage location is a child of the move line's destination location (i.e
-either the put-away location or the move's destination location), then it will
-be searched in order to find a children location that is allowed according to
-the restrictions defined on the stock location storage types.
+either the put-away location or the move's destination location).
+For each location, their packs storage strategy is applied as well as the
+restrictions defined on the stock location storage types.
 If no suitable location is found, the next location in the sequence will be
 searched and so on.
+
+For the packs putaway strategy "none", the location is considered as is.  For
+the "ordered children" strategy, children locations are sorted by first by max
+height which is a physical constraint to respect, then pack putaway sequence
+which allow to favor for example some level or corridor, and finally by name.

--- a/stock_storage_type/tests/common.py
+++ b/stock_storage_type/tests/common.py
@@ -37,8 +37,8 @@ class TestStorageTypeCommon(SavepointCase):
         cls.cardboxes_bin_3_location = ref(
             "stock_storage_type.stock_location_cardboxes_bin_3"
         )
-        cls.cardboxes_bin_4_location = cls.cardboxes_bin_1_location.copy(
-            {"name": "Bin 4"}
+        cls.cardboxes_bin_4_location = ref(
+            "stock_storage_type.stock_location_cardboxes_bin_4"
         )
         cls.env["stock.location"]._parent_store_compute()
         cls.pallets_bin_1_location = ref(
@@ -49,6 +49,9 @@ class TestStorageTypeCommon(SavepointCase):
         )
         cls.pallets_bin_3_location = ref(
             "stock_storage_type.stock_location_pallets_bin_3"
+        )
+        cls.pallets_bin_4_location = ref(
+            "stock_storage_type.stock_location_pallets_bin_4"
         )
 
         cls.receipts_picking_type = ref("stock.picking_type_in")

--- a/stock_storage_type/tests/test_stock_location.py
+++ b/stock_storage_type/tests/test_stock_location.py
@@ -9,7 +9,6 @@ class TestStockLocation(TestStorageTypeCommon):
     def setUpClass(cls):
         super(TestStockLocation, cls).setUpClass()
         ref = cls.env.ref
-        cls.areas.write({"pack_putaway_strategy": "ordered_locations"})
         cls.pallets_reserve_bin_1_location = ref(
             "stock_storage_type.stock_location_pallets_reserve_bin_1"
         )
@@ -19,11 +18,24 @@ class TestStockLocation(TestStorageTypeCommon):
         cls.pallets_reserve_bin_3_location = ref(
             "stock_storage_type.stock_location_pallets_reserve_bin_3"
         )
+        cls.pallets_reserve_bin_4_location = ref(
+            "stock_storage_type.stock_location_pallets_reserve_bin_4"
+        )
 
     def test_get_ordered_leaf_locations(self):
+        sublocation = self.stock_location.copy(
+            {
+                "name": "Sub-location",
+                "pack_putaway_strategy": "ordered_locations",
+                "location_id": self.stock_location.id,
+            }
+        )
+        self.areas.write({"location_id": sublocation.id})
+
         # Test with the same max_height on all related storage types (0 here)
+        ordered_locations = sublocation.get_storage_locations(self.product)
         self.assertEqual(
-            self.areas._get_ordered_leaf_locations().ids,
+            ordered_locations.ids,
             (
                 self.cardboxes_bin_1_location
                 | self.cardboxes_bin_2_location
@@ -32,16 +44,19 @@ class TestStockLocation(TestStorageTypeCommon):
                 | self.pallets_bin_1_location
                 | self.pallets_bin_2_location
                 | self.pallets_bin_3_location
+                | self.pallets_bin_4_location
                 | self.pallets_reserve_bin_1_location
                 | self.pallets_reserve_bin_2_location
                 | self.pallets_reserve_bin_3_location
+                | self.pallets_reserve_bin_4_location
             ).ids,
         )
         # Set the max_height on pallets storage type higher than the others
         self.pallets_location_storage_type.max_height = 2
         self.cardboxes_location_storage_type.max_height = 1
+        ordered_locations = sublocation.get_storage_locations(self.product)
         self.assertEqual(
-            self.areas._get_ordered_leaf_locations().ids,
+            ordered_locations.ids,
             (
                 self.cardboxes_bin_1_location
                 | self.cardboxes_bin_2_location
@@ -50,23 +65,28 @@ class TestStockLocation(TestStorageTypeCommon):
                 | self.pallets_bin_1_location
                 | self.pallets_bin_2_location
                 | self.pallets_bin_3_location
+                | self.pallets_bin_4_location
                 | self.pallets_reserve_bin_1_location
                 | self.pallets_reserve_bin_2_location
                 | self.pallets_reserve_bin_3_location
+                | self.pallets_reserve_bin_4_location
             ).ids,
         )
         # Set the max_height on cardboxes storage type higher than the others
         self.pallets_location_storage_type.max_height = 1
         self.cardboxes_location_storage_type.max_height = 2
+        ordered_locations = sublocation.get_storage_locations(self.product)
         self.assertEqual(
-            self.areas._get_ordered_leaf_locations().ids,
+            ordered_locations.ids,
             (
                 self.pallets_bin_1_location
                 | self.pallets_bin_2_location
                 | self.pallets_bin_3_location
+                | self.pallets_bin_4_location
                 | self.pallets_reserve_bin_1_location
                 | self.pallets_reserve_bin_2_location
                 | self.pallets_reserve_bin_3_location
+                | self.pallets_reserve_bin_4_location
                 | self.cardboxes_bin_1_location
                 | self.cardboxes_bin_2_location
                 | self.cardboxes_bin_3_location

--- a/stock_storage_type/tests/test_storage_type.py
+++ b/stock_storage_type/tests/test_storage_type.py
@@ -31,6 +31,9 @@ class TestStorageType(SavepointCase):
         cls.cardboxes_bin_3 = cls.env.ref(
             "stock_storage_type.stock_location_cardboxes_bin_3"
         )
+        cls.cardboxes_bin_4 = cls.env.ref(
+            "stock_storage_type.stock_location_cardboxes_bin_4"
+        )
         cls.env["stock.location"]._parent_store_compute()
 
     def test_location_allowed_storage_types(self):

--- a/stock_storage_type/views/stock_location.xml
+++ b/stock_storage_type/views/stock_location.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="removal_strategy_id" position="after">
                 <field name="pack_putaway_strategy" />
+                <field name="pack_putaway_sequence" />
                 <field
                     name="allowed_location_storage_type_ids"
                     widget="many2many_tags"


### PR DESCRIPTION
Invert the sorting for abc packs storage strategy to first apply the
max_height which is a physical constraint, then apply the abc
preference.

Add a pack putaway sequence to be able to favor some locations (e.g.
level). For ordered children strategy, finalize by sorting by location
name. For abc, random selection is applied at last as it was already.

Replaced multi-steps python sorting by an unique SQL quicksort query to
quickly compute the result on large stock_location table. This is
especially important for operations containing many moves requiring a
putaway computation.

Backport of https://github.com/OCA/wms/pull/237