### PR TITLE
Change sorting of locations in the pack putaway computation

### DIFF
--- a/stock_storage_type_putaway_abc/README.rst
+++ b/stock_storage_type_putaway_abc/README.rst
@@ -28,10 +28,20 @@ Stock Storage Type ABC Strategy
 This module implements chaotic storage 'ABC' according to Package Storage Type
 and Location Storage Type.
 
-.. IMPORTANT::
-   This is an alpha version, the data model and design can change at any time without warning.
-   Only for development or testing purpose, do not use in production.
-   `More details on development status <https://odoo-community.org/page/development-status>`_
+The locations and products get an 'a', 'b' or 'c' storage (by default 'b').
+
+For the computation of the putaway, the locations are sorted first by max
+height which is a physical constain to respect, then by 'ABC' following that:
+
+* if the product is 'a', then locations are sorted by 'a', 'b', 'c'
+* if the product is 'b', then locations are sorted by 'b', 'c', 'a'
+* if the product is 'c', then locations are sorted by 'c', 'b', 'a'
+
+Then by pack putaway sequence (this allow to favor for example some level or
+corridor), and finally randomly.
+
+The storage type putaway computation will then apply on the list of locations
+the additional restrictions and take the first valid location.
 
 **Table of contents**
 
@@ -55,11 +65,13 @@ Authors
 ~~~~~~~
 
 * Camptocamp
+* BCIM
 
 Contributors
 ~~~~~~~~~~~~
 
 * Akim Juillerat <akim.juillerat@camptocamp.com>
+* Jacques-Etienne Baudoux <je@bcim.be>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_storage_type_putaway_abc/__manifest__.py
+++ b/stock_storage_type_putaway_abc/__manifest__.py
@@ -1,13 +1,13 @@
-# Copyright 2019 Camptocamp SA
+# Copyright 2019-2021 Camptocamp SA
+# Copyright 2019-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 {
     "name": "Stock Storage Type ABC Strategy",
     "summary": "Advanced storage strategy ABC for WMS",
-    "version": "10.0.1.1.0",
-    "development_status": "Alpha",
+    "version": "10.0.1.2.0",
     "category": "Warehouse Management",
     "website": "https://github.com/OCA/wms",
-    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/stock_storage_type_putaway_abc/models/stock_location.py
+++ b/stock_storage_type_putaway_abc/models/stock_location.py
@@ -1,26 +1,11 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 Camptocamp SA
+# Copyright 2019-2021 Camptocamp SA
+# Copyright 2019-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from random import shuffle
-
 from odoo import api, fields, models
 from odoo.fields import first
 
 ABC_SELECTION = [("a", "A"), ("b", "B"), ("c", "C")]
-
-
-def gather_location_ids(abc_sorted, max_heights_sorted, locations_grouped):
-    """Return a list of location IDs sorted on `abc_sorted` then
-    on `max_heights_sorted`.
-    """
-    location_ids = []
-    for abc_key in abc_sorted:
-        group_ids_per_height = locations_grouped.get(abc_key)
-        if not group_ids_per_height:
-            continue
-        for max_height in max_heights_sorted:
-            location_ids.extend(group_ids_per_height.get(max_height, []))
-    return location_ids
 
 
 class StockLocation(models.Model):
@@ -48,51 +33,20 @@ class StockLocation(models.Model):
                     current_location = current_location.location_id
             location.display_abc_storage = display_abc_storage
 
-    def get_storage_locations(self, products=None):
-        if products is None:
-            products = self.env["product.product"]
-        if self.pack_putaway_strategy == "abc":
-            return self._get_abc_locations(products)
-        return super(StockLocation, self).get_storage_locations(products)
-
-    def _get_abc_locations(self, products):
-        return self.leaf_location_ids._sort_abc_locations(first(products).abc_storage)
-
-    def _sort_abc_locations(self, product_abc):
-        product_abc = product_abc or "a"
-        # group locations by abc_storage and max_height
-        data = self.read_group(
-            [("id", "in", self.ids)], ["max_height"], ["max_height"],
-        )
-        locations_grouped = {}
-        max_heights = set()
-        for line in data:
-            domain = line["__domain"]
-            locations = self.search(domain)
-            for loc in locations:
-                locations_grouped.setdefault(loc.abc_storage, {}).setdefault(
-                    line["max_height"], []
-                )
-                locations_grouped[loc.abc_storage][line["max_height"]].append(loc.id)
-            # keep a list of available max heights
-            max_heights.add(line["max_height"])
-        # sort max heights and take care to put any 0 value at the end
-        max_heights = list(max_heights)
-        max_heights.sort()
-        if 0 in max_heights:
-            max_heights.pop(max_heights.index(0))
-            max_heights.append(0)
-        # shuffle each abc_storage/max_height chunk
-        for line in locations_grouped.values():
-            for max_height in line:
-                shuffle(line[max_height])
-        # prepare the result
+    def _get_sorted_leaf_locations_orderby(self, products):
+        if not self.pack_putaway_strategy == "abc":
+            return super()._get_sorted_leaf_locations_orderby(products)
+        product_abc = first(products).abc_storage or "a"
         if product_abc == "a":
-            location_ids = gather_location_ids("abc", max_heights, locations_grouped)
+            abc_seq = "a", "b", "c"
         elif product_abc == "b":
-            location_ids = gather_location_ids("bca", max_heights, locations_grouped)
+            abc_seq = "b", "c", "a"
         elif product_abc == "c":
-            location_ids = gather_location_ids("cba", max_heights, locations_grouped)
-        else:
-            raise ValueError("product_abc = %s" % product_abc)
-        return self.env["stock.location"].browse(location_ids)
+            abc_seq = "c", "b", "a"
+        orderby = [
+            "CASE WHEN max_height > 0 THEN max_height ELSE 'Infinity' END",
+            "array_position(%s, abc_storage::text)",
+            "pack_putaway_sequence",
+            "random()",
+        ]
+        return ", ".join(orderby), [list(abc_seq)]

--- a/stock_storage_type_putaway_abc/readme/CONTRIBUTORS.rst
+++ b/stock_storage_type_putaway_abc/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Akim Juillerat <akim.juillerat@camptocamp.com>
+* Jacques-Etienne Baudoux <je@bcim.be>

--- a/stock_storage_type_putaway_abc/readme/DESCRIPTION.rst
+++ b/stock_storage_type_putaway_abc/readme/DESCRIPTION.rst
@@ -1,2 +1,17 @@
 This module implements chaotic storage 'ABC' according to Package Storage Type
 and Location Storage Type.
+
+The locations and products get an 'a', 'b' or 'c' storage (by default 'b').
+
+For the computation of the putaway, the locations are sorted first by max
+height which is a physical constain to respect, then by 'ABC' following that:
+
+* if the product is 'a', then locations are sorted by 'a', 'b', 'c'
+* if the product is 'b', then locations are sorted by 'b', 'c', 'a'
+* if the product is 'c', then locations are sorted by 'c', 'b', 'a'
+
+Then by pack putaway sequence (this allow to favor for example some level or
+corridor), and finally randomly.
+
+The storage type putaway computation will then apply on the list of locations
+the additional restrictions and take the first valid location.

--- a/stock_storage_type_putaway_abc/tests/test_abc_location.py
+++ b/stock_storage_type_putaway_abc/tests/test_abc_location.py
@@ -1,5 +1,10 @@
+<<<<<<< HEAD
 # -*- coding: utf-8 -*-
 # Copyright 2019 Camptocamp SA
+=======
+# Copyright 2019-2021 Camptocamp SA
+# Copyright 2019-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+>>>>>>> Change sorting of locations in the pack putaway computation
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo.tests import SavepointCase
 
@@ -19,72 +24,96 @@ class TestAbcLocation(SavepointCase):
         cls.stock_location = ref("stock.stock_location_stock")
         cls.cardboxes_location = ref("stock_storage_type.stock_location_cardboxes")
         cls.pallets_location = ref("stock_storage_type.stock_location_pallets")
-        cls.cardboxes_bin_1_location = ref(
-            "stock_storage_type.stock_location_cardboxes_bin_1"
-        )
-        cls.cardboxes_bin_2_location = ref(
+        cls.cardboxes_bin_a_location = ref(
             "stock_storage_type.stock_location_cardboxes_bin_2"
         )
-        cls.cardboxes_bin_3_location = ref(
+        cls.cardboxes_bin_b1_location = ref(
+            "stock_storage_type.stock_location_cardboxes_bin_4"
+        )
+        cls.cardboxes_bin_b2_location = ref(
+            "stock_storage_type.stock_location_cardboxes_bin_1"
+        )
+        cls.cardboxes_bin_c_location = ref(
             "stock_storage_type.stock_location_cardboxes_bin_3"
         )
-        cls.pallets_bin_1_location = ref(
-            "stock_storage_type.stock_location_pallets_bin_1"
+        cls.pallets_bin_a_location = ref(
+            "stock_storage_type.stock_location_pallets_bin_3"
         )
-        cls.pallets_bin_2_location = ref(
+        cls.pallets_bin_b1_location = ref(
+            "stock_storage_type.stock_location_pallets_bin_4"
+        )
+        cls.pallets_bin_b2_location = ref(
             "stock_storage_type.stock_location_pallets_bin_2"
         )
-        cls.pallets_bin_3_location = ref(
-            "stock_storage_type.stock_location_pallets_bin_3"
+        cls.pallets_bin_c_location = ref(
+            "stock_storage_type.stock_location_pallets_bin_1"
         )
         cls.product = ref("product.product_product_9")
         cls.env["stock.location"]._parent_store_compute()
 
     def test_display_abc_storage_one_level(self):
         self.cardboxes_location.write({"pack_putaway_strategy": "abc"})
-        self.assertTrue(self.cardboxes_bin_1_location.display_abc_storage)
-        self.assertTrue(self.cardboxes_bin_2_location.display_abc_storage)
-        self.assertTrue(self.cardboxes_bin_3_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_1_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_2_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_3_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_a_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_b1_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_b2_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_c_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_a_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_b1_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_b2_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_c_location.display_abc_storage)
         self.cardboxes_location.write({"pack_putaway_strategy": "ordered_locations"})
-        self.assertFalse(self.cardboxes_bin_1_location.display_abc_storage)
-        self.assertFalse(self.cardboxes_bin_2_location.display_abc_storage)
-        self.assertFalse(self.cardboxes_bin_3_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_1_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_2_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_3_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_a_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_b1_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_b2_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_c_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_a_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_b1_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_b2_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_c_location.display_abc_storage)
 
     def test_display_abc_storage_two_levels(self):
         self.stock_location.write({"pack_putaway_strategy": "abc"})
-        self.assertTrue(self.cardboxes_bin_1_location.display_abc_storage)
-        self.assertTrue(self.cardboxes_bin_2_location.display_abc_storage)
-        self.assertTrue(self.cardboxes_bin_3_location.display_abc_storage)
-        self.assertTrue(self.pallets_bin_1_location.display_abc_storage)
-        self.assertTrue(self.pallets_bin_2_location.display_abc_storage)
-        self.assertTrue(self.pallets_bin_3_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_a_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_b1_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_b2_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_c_location.display_abc_storage)
+        self.assertTrue(self.pallets_bin_a_location.display_abc_storage)
+        self.assertTrue(self.pallets_bin_b1_location.display_abc_storage)
+        self.assertTrue(self.pallets_bin_b2_location.display_abc_storage)
+        self.assertTrue(self.pallets_bin_c_location.display_abc_storage)
         self.stock_location.write({"pack_putaway_strategy": "none"})
-        self.assertFalse(self.cardboxes_bin_1_location.display_abc_storage)
-        self.assertFalse(self.cardboxes_bin_2_location.display_abc_storage)
-        self.assertFalse(self.cardboxes_bin_3_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_1_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_2_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_3_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_a_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_b1_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_b2_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_c_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_a_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_b1_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_b2_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_c_location.display_abc_storage)
 
     def test_abc_ordered(self):
         self.cardboxes_location.write({"pack_putaway_strategy": "abc"})
-        self.cardboxes_bin_1_location.write({"abc_storage": "b"})
-        self.cardboxes_bin_2_location.write({"abc_storage": "a"})
-        self.cardboxes_bin_3_location.write({"abc_storage": "c"})
+        self.cardboxes_bin_a_location.write(
+            {"abc_storage": "a", "pack_putaway_sequence": 3}
+        )
+        self.cardboxes_bin_b1_location.write(
+            {"abc_storage": "b", "pack_putaway_sequence": 1}
+        )
+        self.cardboxes_bin_b2_location.write(
+            {"abc_storage": "b", "pack_putaway_sequence": 2}
+        )
+        self.cardboxes_bin_c_location.write(
+            {"abc_storage": "c", "pack_putaway_sequence": 1}
+        )
         self.product.write({"abc_storage": "a"})
         ordered_locations = self.cardboxes_location.get_storage_locations(self.product)
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_2_location
-                | self.cardboxes_bin_1_location
-                | self.cardboxes_bin_3_location
+                self.cardboxes_bin_a_location
+                | self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
             ).ids,
         )
         self.product.write({"abc_storage": "b"})
@@ -92,9 +121,10 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_1_location
-                | self.cardboxes_bin_3_location
-                | self.cardboxes_bin_2_location
+                self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
+                | self.cardboxes_bin_a_location
             ).ids,
         )
         self.product.write({"abc_storage": "c"})
@@ -102,9 +132,10 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_3_location
-                | self.cardboxes_bin_1_location
-                | self.cardboxes_bin_2_location
+                self.cardboxes_bin_c_location
+                | self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_a_location
             ).ids,
         )
 
@@ -120,12 +151,22 @@ class TestAbcLocation(SavepointCase):
         # configure putaway strategy for all locations
         sublocation.write({"pack_putaway_strategy": "abc"})
         # configure abc storage on locations
-        self.cardboxes_bin_1_location.write({"abc_storage": "b"})
-        self.cardboxes_bin_2_location.write({"abc_storage": "a"})
-        self.cardboxes_bin_3_location.write({"abc_storage": "c"})
-        self.pallets_bin_1_location.write({"abc_storage": "b"})
-        self.pallets_bin_2_location.write({"abc_storage": "a"})
-        self.pallets_bin_3_location.write({"abc_storage": "c"})
+        self.cardboxes_bin_a_location.write({"abc_storage": "a"})
+        self.cardboxes_bin_b1_location.write(
+            {"abc_storage": "b", "pack_putaway_sequence": 1}
+        )
+        self.cardboxes_bin_b2_location.write(
+            {"abc_storage": "b", "pack_putaway_sequence": 2}
+        )
+        self.cardboxes_bin_c_location.write({"abc_storage": "c"})
+        self.pallets_bin_a_location.write({"abc_storage": "a"})
+        self.pallets_bin_b1_location.write(
+            {"abc_storage": "b", "pack_putaway_sequence": 1}
+        )
+        self.pallets_bin_b2_location.write(
+            {"abc_storage": "b", "pack_putaway_sequence": 2}
+        )
+        self.pallets_bin_c_location.write({"abc_storage": "c"})
         # Test with a product abc_storage=A
         #   - with max height on pallets storage type higher than the cardboxes one
         self.product.write({"abc_storage": "a"})
@@ -135,12 +176,14 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_2_location
-                | self.pallets_bin_2_location
-                | self.cardboxes_bin_1_location
-                | self.pallets_bin_1_location
-                | self.cardboxes_bin_3_location
-                | self.pallets_bin_3_location
+                self.cardboxes_bin_a_location
+                | self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
+                | self.pallets_bin_a_location
+                | self.pallets_bin_b1_location
+                | self.pallets_bin_b2_location
+                | self.pallets_bin_c_location
             ).ids,
         )
         #   - with max height on cardboxes storage type higher than the pallets one
@@ -150,12 +193,14 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.pallets_bin_2_location
-                | self.cardboxes_bin_2_location
-                | self.pallets_bin_1_location
-                | self.cardboxes_bin_1_location
-                | self.pallets_bin_3_location
-                | self.cardboxes_bin_3_location
+                self.pallets_bin_a_location
+                | self.pallets_bin_b1_location
+                | self.pallets_bin_b2_location
+                | self.pallets_bin_c_location
+                | self.cardboxes_bin_a_location
+                | self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
             ).ids,
         )
         #   - with max height "no-limit" on pallets storage type
@@ -165,12 +210,14 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_2_location
-                | self.pallets_bin_2_location
-                | self.cardboxes_bin_1_location
-                | self.pallets_bin_1_location
-                | self.cardboxes_bin_3_location
-                | self.pallets_bin_3_location
+                self.cardboxes_bin_a_location
+                | self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
+                | self.pallets_bin_a_location
+                | self.pallets_bin_b1_location
+                | self.pallets_bin_b2_location
+                | self.pallets_bin_c_location
             ).ids,
         )
         # Test with a product abc_storage=B
@@ -182,12 +229,14 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_1_location
-                | self.pallets_bin_1_location
-                | self.cardboxes_bin_3_location
-                | self.pallets_bin_3_location
-                | self.cardboxes_bin_2_location
-                | self.pallets_bin_2_location
+                self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
+                | self.cardboxes_bin_a_location
+                | self.pallets_bin_b1_location
+                | self.pallets_bin_b2_location
+                | self.pallets_bin_c_location
+                | self.pallets_bin_a_location
             ).ids,
         )
         #   - with max height on cardboxes storage type higher than the pallets one
@@ -197,12 +246,14 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.pallets_bin_1_location
-                | self.cardboxes_bin_1_location
-                | self.pallets_bin_3_location
-                | self.cardboxes_bin_3_location
-                | self.pallets_bin_2_location
-                | self.cardboxes_bin_2_location
+                self.pallets_bin_b1_location
+                | self.pallets_bin_b2_location
+                | self.pallets_bin_c_location
+                | self.pallets_bin_a_location
+                | self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
+                | self.cardboxes_bin_a_location
             ).ids,
         )
         #   - with max height "no-limit" on pallets storage type
@@ -212,12 +263,14 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_1_location
-                | self.pallets_bin_1_location
-                | self.cardboxes_bin_3_location
-                | self.pallets_bin_3_location
-                | self.cardboxes_bin_2_location
-                | self.pallets_bin_2_location
+                self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
+                | self.cardboxes_bin_a_location
+                | self.pallets_bin_b1_location
+                | self.pallets_bin_b2_location
+                | self.pallets_bin_c_location
+                | self.pallets_bin_a_location
             ).ids,
         )
 
@@ -227,4 +280,4 @@ class TestAbcLocation(SavepointCase):
         self.env["stock.location"].search([("abc_storage", "in", ("a", "b"))]).write(
             {"abc_storage": "b"}
         )
-        self.assertTrue(self.stock_location.get_storage_locations())
+        self.assertTrue(self.stock_location.get_storage_locations(self.product))


### PR DESCRIPTION
Invert the sorting for abc packs storage strategy to first apply the
max_height which is a physical constraint, then apply the abc
preference.

Add a pack putaway sequence to be able to favor some locations (e.g.
level). For ordered children strategy, finalize by sorting by location
name. For abc, random selection is applied at last as it was already.

Replaced multi-steps python sorting by an unique SQL quicksort query to
quickly compute the result on large stock_location table. This is
especially important for operations containing many moves requiring a
putaway computation.

Backport of https://github.com/OCA/wms/pull/237