### PR TITLE
[FIX] stock_storage_type: Fix putaway compution when a strategy is defined

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -188,8 +188,7 @@ class StockLocation(models.Model):
         for loc in self:
             leave_ids = rows.get(loc.id)
             if not leave_ids:
-                # if we have no sub-location, we are a leaf
-                loc.leaf_location_ids = loc
+                loc.leaf_location_ids = False
                 continue
             leaves = self.search([("id", "in", leave_ids)])
             loc.leaf_location_ids = leaves


### PR DESCRIPTION
When the strategy has to find a leaf location, do not return non-leaf
locations defined on a storage type putaway sequence.

Example: sequence is defined to first look in WH/Stock/area1 and then in
WH/Stock/area2. On area1 the strategy is to find a leaf location under
area1. If area1 currently has no valid leaf location for the pack storage
type, area1 should not be returned as a valid leaf location.

Backport of https://github.com/OCA/wms/pull/283

cc @lmignon 