### PR TITLE
[16.0][FIX] shopfloor: change lot action & fix inventory

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -25,6 +25,7 @@
         "stock_helper",
         "stock_picking_completion_info",
         #  OCA / stock-logistics-workflow
+        "stock_move_line_change_lot",
         "stock_quant_package_dimension",
         "stock_quant_package_product_packaging",
         "stock_picking_progress",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,6 +6,7 @@ odoo-addon-shopfloor-base @ git+https://github.com/OCA/wms.git@refs/pull/642/hea
 
 # OCA/stock-logistics-workflow
 odoo-addon-stock-picking-progress @ git+https://github.com/OCA/stock-logistics-workflow.git@refs/pull/1330/head#subdirectory=setup/stock_picking_progress
+odoo-addon-stock-move-line-change-lot @ git+https://github.com/OCA/stock-logistics-workflow.git@refs/pull/1469/head#subdirectory=setup/stock_move_line_change_lot
 
 # OCA/product-attribute
 odoo-addon-product-packaging-level @ git+https://github.com/OCA/product-attribute.git@refs/pull/1215/head#subdirectory=setup/product_packaging_level


### PR DESCRIPTION
Depends on:
* https://github.com/OCA/stock-logistics-workflow/pull/1469

Changes:
* Fixed control inventory by setting a date and also a value to prevent the quant to be cleaned up when viewing them. Only create a new control quant if none can be found, otherwise mark existing quant.
* Extracted complexity in a new module. This also allows to have the same behavior in the backend
* Inform user when quantity has changed

cc @sbejaoui @sebalix